### PR TITLE
Make AccessProof contracts optional

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -37,10 +37,17 @@ jobs:
       run: |
         pip install pip==20.2.4
         pip install -r requirements_dev.txt
-    - name: Test
+    - name: Unit tests
       run: |
         export PARITY_ADDRESS=0x00bd138abd70e2f00903268f3db08f2d25677c9e
         export PARITY_PASSWORD=node0
         export PARITY_KEYFILE=tests/resources/data/publisher_key_file.json
         export INFURA_TOKEN=${{ secrets.INFURA_TOKEN }}
         pytest -v
+    - name: Integration tests
+      run: |
+        export PARITY_ADDRESS=0x00bd138abd70e2f00903268f3db08f2d25677c9e
+        export PARITY_PASSWORD=node0
+        export PARITY_KEYFILE=tests/resources/data/publisher_key_file.json
+        export INFURA_TOKEN=${{ secrets.INFURA_TOKEN }}
+        pytest -v -m integration

--- a/contracts_lib_py/keeper.py
+++ b/contracts_lib_py/keeper.py
@@ -79,21 +79,16 @@ class Keeper(object):
             self._external_contract_name_to_instance[name] = contract
             setattr(self, name, contract)
 
-        # make dispenser and token contracts optional
-        try:
-            self.dispenser = Dispenser.get_instance()
-        except FileNotFoundError:
-            self.dispenser = None
+        # optional contracts (contracts that may not exist in certain networks)
+        self.access_proof_template = self._try_optional_contract(AccessProofTemplate)
+        self.access_proof_condition = self._try_optional_contract(AccessProofCondition)
+        self.dispenser = self._try_optional_contract(Dispenser)
+        self.token = self._try_optional_contract(Token)
 
-        try:
-            self.token = Token.get_instance()
-        except FileNotFoundError:
-            self.token = None
-
+        # required contracts
         self.did_registry = DIDRegistry.get_instance()
         self.template_manager = TemplateStoreManager.get_instance()
         self.access_template = AccessTemplate.get_instance()
-        self.access_proof_template = AccessProofTemplate.get_instance()
         self.escrow_compute_execution_template = EscrowComputeExecutionTemplate.get_instance()
         self.agreement_manager = AgreementStoreManager.get_instance()
         self.condition_manager = ConditionStoreManager.get_instance()
@@ -101,7 +96,6 @@ class Keeper(object):
         self.lock_payment_condition = LockPaymentCondition.get_instance()
         self.escrow_payment_condition = EscrowPaymentCondition.get_instance()
         self.access_condition = AccessCondition.get_instance()
-        self.access_proof_condition = AccessProofCondition.get_instance()
         self.nft_access_condition = NFTAccessCondition.get_instance()
         self.compute_execution_condition = ComputeExecutionCondition.get_instance()
         self.hash_lock_condition = HashLockCondition.get_instance()
@@ -258,3 +252,10 @@ class Keeper(object):
     @staticmethod
     def generate_multi_value_hash(types, values):
         return generate_multi_value_hash(types, values)
+
+    @staticmethod
+    def _try_optional_contract(contract):
+        try:
+            return contract.get_instance()
+        except FileNotFoundError:
+            return None

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    integration: mark a test as an integration tests
+addopts = -v -m "not integration"

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/nevermined-io/contracts-lib-py',
-    version='0.7.15',
+    version='0.7.16',
     zip_safe=False,
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,8 +13,10 @@ from tests.resources.helper_functions import (
 
 
 @pytest.fixture(autouse=True)
-def setup_all():
-   setup_keeper()
+def setup_all(request):
+    if 'integration' in request.keywords:
+        return
+    setup_keeper()
 
 
 @pytest.fixture

--- a/tests/resources/helper_functions.py
+++ b/tests/resources/helper_functions.py
@@ -29,8 +29,7 @@ def setup_keeper():
 
 
 def get_network_name():
-    setup_keeper()
-    return Keeper.get_network_name(Keeper.get_network_id())
+    return Keeper.get_instance().get_network_name(Keeper.get_instance().get_network_id())
 
 
 def get_resource_path(dir_name, file_name):

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -11,12 +11,14 @@ from contracts_lib_py.keeper import Keeper
 
 INFURA_TOKEN = os.environ.get("INFURA_TOKEN")
 
+pytestmark = pytest.mark.integration
+
 
 @pytest.mark.parametrize("keeper_url,network_id,network_name", [
     [f"https://mainnet.infura.io/v3/{INFURA_TOKEN}", 1, "mainnet"],
     [f"https://rinkeby.infura.io/v3/{INFURA_TOKEN}", 4, "rinkeby"],
     ("http://localhost:8545", 8996, "spree"),
-    ("https://rpc-mumbai.matic.today", 80001, "mumbai"),
+    (f"https://polygon-mumbai.infura.io/v3/{INFURA_TOKEN}", 80001, "mumbai"),
     ("https://alfajores-forno.celo-testnet.org", 44787, "celo-alfajores"),
     ("https://baklava-forno.celo-testnet.org", 62320, "celo-baklava")
 ])

--- a/tests/test_dispenser.py
+++ b/tests/test_dispenser.py
@@ -2,14 +2,7 @@
 import pytest
 
 from contracts_lib_py.dispenser import Dispenser
-from tests.resources.helper_functions import get_consumer_account, get_network_name
-
-
-# skip NeverminedToken tests if not running on the spree network
-pytestmark = pytest.mark.skipif(
-    get_network_name() != "spree",
-    reason="Dispenser tests should only run on the `spree` network"
-)
+from tests.resources.helper_functions import get_consumer_account
 
 
 @pytest.fixture()

--- a/tests/test_token.py
+++ b/tests/test_token.py
@@ -5,17 +5,10 @@ from web3 import Web3
 from contracts_lib_py.conditions import LockPaymentCondition
 from contracts_lib_py.token import Token
 from contracts_lib_py.keeper import Keeper
-from tests.resources.helper_functions import get_consumer_account, get_publisher_account, get_network_name
+from tests.resources.helper_functions import get_consumer_account, get_publisher_account
 
 consumer_account = get_consumer_account()
 publisher_account = get_publisher_account()
-
-
-# skip NeverminedToken tests if not running on the spree network
-pytestmark = pytest.mark.skipif(
-    get_network_name() != "spree",
-    reason="NeverminedToken tests should only run on the `spree` network"
-)
 
 
 def test_token_contract():


### PR DESCRIPTION
## Description

Fixes a bug where it can't load the new `AccessProofs` artifacts when connected to certain networks

- Makes `AccessProofs` contracts optional
- Fixes the artifact tests to make sure it fails if artifacts cannot be loaded

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [x] Tests Cover Changes
- [ ] Documentation
