### PR TITLE
Small fix so the keeper works with polygon

### DIFF
--- a/contracts_lib_py/keeper.py
+++ b/contracts_lib_py/keeper.py
@@ -52,6 +52,7 @@ class Keeper(object):
         99: 'POA_Core',
         8995: 'nile',
         8996: 'spree',
+        8997: 'polygon-localnet',
         2199: 'duero',
         0xcea11: 'pacific',
         44787: 'celo-alfajores',
@@ -65,6 +66,19 @@ class Keeper(object):
     def __init__(self, artifacts_path=None, contract_names=None, external_contracts=[]):
         self.network_name = Keeper.get_network_name(Keeper.get_network_id())
         self.artifacts_path = artifacts_path or nevermined_contracts.get_artifacts_path()
+
+        # This api is not provided by polygon
+        # Not sure if it makes sense to use `eth.accounts` since in order to
+        # interact with the accounts in the node we need to be running our own node
+        try:
+            self.accounts = Web3Provider.get_web3().eth.accounts
+        except ValueError as e:
+            # method does not exist or is not available
+            if e.args[0]['code'] == -32601:
+                self.accounts = []
+            else:
+                raise
+
         self.accounts = Web3Provider.get_web3().eth.accounts
         self._contract_name_to_instance = {}
         self._external_contract_name_to_instance = {}

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/nevermined-io/contracts-lib-py',
-    version='0.7.17',
+    version='0.7.18',
     zip_safe=False,
 )


### PR DESCRIPTION
## Description

The `eth.accounts` api is not provided by polygon. Also I think this api only makes sense if you are running your localnode

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation
